### PR TITLE
Make encoding/buffer overrideable

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ waveform(audiofile, {
   'png-color-bg': '00000000',     // bg color, rrggbbaa
   'png-color-center': '000000ff', // gradient center color, rrggbbaa
   'png-color-outer': '000000ff',  // gradient outer color, rrggbbaa
+
+  // node-specific options
+  encoding: "utf8",               // different output encoding for callback (default is 'buffer')
+  maxBuffer: 1024 * 1000          // max buffer before the process is killed (default is 1024 * 5000)
+
 }, function(err, buf) {
   // done
 });

--- a/index.js
+++ b/index.js
@@ -7,11 +7,18 @@ var flagNames = {
   'wjs-plain': true,
 };
 
+var processOptions = {
+  encoding: 'buffer',
+  maxBuffer: 5000 * 1024
+};
+
 module.exports = function(audiofile, options, callback) {
   var cmdline = [audiofile];
   for (var optName in options) {
     if (flagNames[optName]) {
       cmdline.push('--' + optName);
+    } else if (processOptions[optName]){
+      processOptions[optName] = options[optName];
     } else {
       var value = options[optName];
       cmdline.push('--' + optName);
@@ -19,7 +26,7 @@ module.exports = function(audiofile, options, callback) {
     }
   }
 
-  execFile(waveformBin, cmdline, {encoding: 'buffer', maxBuffer: 5000*1024}, function(err, stdout, stderr) {
+  execFile(waveformBin, cmdline, processOptions, function(err, stdout, stderr) {
     if (err) {
       err.stdout = stdout;
       err.stderr = stderr;


### PR DESCRIPTION
Closes #6 by allowing you to set the encoding explicitly for the callback.  Also added ability to specify the maxBuffer (currently hardcoded as 5000 \* 1024).
